### PR TITLE
Add oauth2_proxy chart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.7
+
+# Install CA certificates
+RUN apk add --no-cache --virtual=build-dependencies ca-certificates
+
+# Checkout bitly's latest auth_proxy 2.2.0 release from Github
+ADD https://github.com/bitly/oauth2_proxy/releases/download/v2.2/oauth2_proxy-2.2.0.linux-amd64.go1.8.1.tar.gz /tmp
+RUN tar -xf /tmp/oauth2_proxy-2.2.0.linux-amd64.go1.8.1.tar.gz -C ./bin --strip-components=1 && rm /tmp/*.tar.gz
+
+# Expose the ports we need and setup the ENTRYPOINT w/ the default argument to be passed in.
+EXPOSE 8080 4180
+ENTRYPOINT [ "./bin/oauth2_proxy" ]
+CMD [ "--upstream=http://0.0.0.0:8080/", "--http-address=0.0.0.0:4180" ]

--- a/helm/g8s-oauth2-proxy-chart/Chart.yaml
+++ b/helm/g8s-oauth2-proxy-chart/Chart.yaml
@@ -1,0 +1,2 @@
+name: g8s-oauth2-proxy-chart
+version: 1.0.0-[[ .SHA ]]

--- a/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
+++ b/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
@@ -16,7 +16,9 @@ spec:
         k8s-app: oauth2-proxy
     spec:
       containers:
-      - args:
+      - image: quay.io/giantswarm/oauth2_proxy:2.2
+        name: oauth2-proxy
+        args:
         - --cookie-expire=0h30m0s
         - --email-domain="giantswarm.io"
         - --http-address=0.0.0.0:4180
@@ -24,15 +26,27 @@ spec:
         - --upstream=file:///dev/null
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
-          value:
+          valueFrom:
+            secretKeyRef:
+              name: oauth2-proxy-secret
+              key: client-id
         - name: OAUTH2_PROXY_CLIENT_SECRET
-          value:
-        # python -c 'import os,base64; print base64.b64encode(os.urandom(16))'
+          valueFrom:
+            secretKeyRef:
+              name: oauth2-proxy-secret
+              key: client-secret
         - name: OAUTH2_PROXY_COOKIE_SECRET
-          value:
-        image: quay.io/giantswarm/oauth2_proxy:2.2
-        imagePullPolicy: Always
-        name: oauth2-proxy
+          valueFrom:
+            secretKeyRef:
+              name: oauth2-proxy-secret
+              key: cookie-secret
         ports:
         - containerPort: 4180
           protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
+++ b/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: oauth2-proxy
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       k8s-app: oauth2-proxy

--- a/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
+++ b/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         k8s-app: oauth2-proxy
     spec:
       containers:
-      - image: quay.io/giantswarm/oauth2_proxy:2.2
+      - image: quay.io/giantswarm/g8s-oauth2-proxy:[[ .SHA ]]
         name: oauth2-proxy
         args:
         - --cookie-expire=0h30m0s

--- a/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
+++ b/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         name: oauth2-proxy
         args:
         - --cookie-expire=0h30m0s
-        - --email-domain="giantswarm.io"
+        - --email-domain=giantswarm.io
         - --http-address=0.0.0.0:4180
         - --provider=google
         - --upstream=file:///dev/null

--- a/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
+++ b/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: oauth2-proxy
+  name: oauth2-proxy
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        k8s-app: oauth2-proxy
+    spec:
+      containers:
+      - args:
+        - --cookie-expire=0h30m0s
+        - --email-domain="giantswarm.io"
+        - --http-address=0.0.0.0:4180
+        - --provider=google
+        - --upstream=file:///dev/null
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          value:
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          value:
+        # python -c 'import os,base64; print base64.b64encode(os.urandom(16))'
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          value:
+        image: quay.io/giantswarm/oauth2_proxy:2.2
+        imagePullPolicy: Always
+        name: oauth2-proxy
+        ports:
+        - containerPort: 4180
+          protocol: TCP

--- a/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
+++ b/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
@@ -44,6 +44,16 @@ spec:
         - name: oauth2-proxy
           containerPort: 4180
           protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: 4180
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        readinessProbe:
+          tcpSocket:
+            port: 4180
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
         resources:
           limits:
             cpu: 100m

--- a/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
+++ b/helm/g8s-oauth2-proxy-chart/templates/deployment.yaml
@@ -41,7 +41,8 @@ spec:
               name: oauth2-proxy-secret
               key: cookie-secret
         ports:
-        - containerPort: 4180
+        - name: oauth2-proxy
+          containerPort: 4180
           protocol: TCP
         resources:
           limits:

--- a/helm/g8s-oauth2-proxy-chart/templates/secret.yaml
+++ b/helm/g8s-oauth2-proxy-chart/templates/secret.yaml
@@ -3,7 +3,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: oauth2-proxy-secret
-  namespace: oauth2-proxy
+  namespace: kube-system
   labels:
     k8s-app: oauth2-proxy
 data:

--- a/helm/g8s-oauth2-proxy-chart/templates/secret.yaml
+++ b/helm/g8s-oauth2-proxy-chart/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: oauth2-proxy-secret
+  namespace: oauth2-proxy
+  labels:
+    k8s-app: oauth2-proxy
+data:
+  client-id: {{ .Values.Installation.V1.Secret.OAuth2Proxy.ClientID | b64enc | quote }}
+  client-secret: {{ .Values.Installation.V1.Secret.OAuth2Proxy.ClientSecret | b64enc | quote }}
+  cookie-secret: {{ .Values.Installation.V1.Secret.OAuth2Proxy.CookieSecret | b64enc | quote }}

--- a/helm/g8s-oauth2-proxy-chart/templates/service.yaml
+++ b/helm/g8s-oauth2-proxy-chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: oauth2-proxy
+  name: oauth2-proxy
+  namespace: kube-system
+spec:
+  ports:
+  - name: http
+    port: 4180
+    protocol: TCP
+    targetPort: 4180
+  selector:
+    k8s-app: oauth2-proxy


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/2480

Add chart for the `oauth2_proxy`. This is a new host cluster service that will allow authentification via an OAuth2 Provider and based on this [project](https://github.com/bitly/oauth2_proxy).

We use google directly as an identity provider, since Auth0 or Github doesn't work for us at the moment. Access restriction is to all `@giantswarm.io` email addresses.