### PR TITLE
Allow circleci to deploy to WIP channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
         chmod +x ./architect
         ./architect version
     - run: ./architect build
+    - run:
+        name: Publish chart to CNR using a temporary channel for feature branch deploys
+        command: ./architect publish --pipeline=false --channels=wip-${CIRCLE_SHA1}
     - deploy:
         command: |
           if [ "${CIRCLE_BRANCH}" == "master" ]; then


### PR DESCRIPTION
Currently deploying from feature branches doesn't work - this allows circleci to public to a temporary channel for testing.