### PR TITLE
Adjust service selector

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.4.2
+  architect: giantswarm/architect@2.7.0
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use name from values as endpoint selector in service.
+
 ## [1.1.1] - 2020-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ More options can be found [here](https://github.com/bitly/oauth2_proxy#command-l
 - G8s-Prometheus
 - G8s-Alertmanager
 - G8s-Kibana
+- G8s-Alertmanager-Dashboard
 
 ## Add authentication/authorization to a web frontend
 

--- a/helm/g8s-oauth2-proxy/templates/service.yaml
+++ b/helm/g8s-oauth2-proxy/templates/service.yaml
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: 4180
   selector:
-    k8s-app: oauth2-proxy
+    k8s-app: {{ .Values.name }}


### PR DESCRIPTION
The idea is to align `service selector` with helm name so that you can have multiple oauth2 proxy running. Right now we have this issue in `rfjh2` where we have **two** oauth2 proxy running in different namespaces.

By this we need to change one of the helm charts with a different name because it has some global resources (e.g. ClusterRole, etc.). Changing the value name is fine however it breaks by selecting the endpoints in the service because of the static label selector.